### PR TITLE
fix mpe config paths

### DIFF
--- a/src/np_config/rigs.py
+++ b/src/np_config/rigs.py
@@ -245,21 +245,21 @@ class Rig:
     def mvr_config(self) -> pathlib.Path:
         "Path to MVR config file for this rig."
         return utils.normalize_path(
-            f"//{self.mon}/ProgramData/AIBS_MPE/mvr/config/mvr.ini"
+            f"//{self.mon}/c$/ProgramData/AIBS_MPE/mvr/config/mvr.ini"
         )
     
     @property
     def sync_config(self) -> pathlib.Path:
         "Path to sync config file for this rig."
         return utils.normalize_path(
-            f'//{self.sync}/ProgramData/AIBS_MPE/sync/config/sync.yml'
+            f'//{self.sync}/c$/ProgramData/AIBS_MPE/sync/config/sync.yml'
         )
 
     @property
     def camstim_config(self) -> pathlib.Path:
         "Path to camstim config file for this rig."
         return utils.normalize_path(
-            f'//{self.stim}/ProgramData/AIBS_MPE/camstim/config/camstim.yml'
+            f'//{self.stim}/c$/ProgramData/AIBS_MPE/camstim/config/camstim.yml'
         )
 
 


### PR DESCRIPTION
The mpe path configs supplied previously were incorrect. This changes them to the correct path and this change has been tested on NP2.